### PR TITLE
Don't remove parent directory from pass path (fixes #6)

### DIFF
--- a/pass.py
+++ b/pass.py
@@ -143,7 +143,6 @@ def main(wflow):
         results = wflow.filter(query, rel_paths, key=search_key_for_pw, min_score=20)
 
         for r in results:
-            r = os.path.basename(r)
             r = os.path.splitext(r)[0]
             if sys.version_info >= (3,0):
                 r = shlex.quote(r)


### PR DESCRIPTION
This change fixes an issue in which passwords in subdirectories cannot be read. 

After the fix, the path shown in Alfred includes the relative path from the root of the password store. 

![image](https://user-images.githubusercontent.com/470418/29629377-65a1b9cc-87ed-11e7-977f-b79d8808cd3b.png)

It would be possible to *show* only the basename while still passing the relative path to `pass`, but that wouldn't allow for disambiguation among similar or identically named passwords in different folders.